### PR TITLE
Example file reCaptcha hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,6 @@
  script has many formatting and operational options, most of which can be 
  specified within a variable file "_variables.php" each form.
 
-## To do
-
-These changes apply to my fork of the software. This file does not need to be merged into `foonster/postman`.
-
-- [x] Place variables used by Postman into an array, to prevent from filling the global namespace
-- [ ] Separate functionality of `Email.php` into individual classes
-- [ ] Send `Content-Type: application/json` with JSON responses; perhaps send proper HTTP status codes to simplify AJAX interaction
-
 ## FILES
 
 _postman.php - main processing file.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 These changes apply to my fork of the software. This file does not need to be merged into `foonster/postman`.
 
 - [x] Place variables used by Postman into an array, to prevent from filling the global namespace
-- [] Separate functionality of `Email.php` into individual classes
-- [] Send `Content-Type: application/json` with JSON responses; perhaps send proper HTTP status codes to simplify AJAX interaction
+- [ ] Separate functionality of `Email.php` into individual classes
+- [ ] Send `Content-Type: application/json` with JSON responses; perhaps send proper HTTP status codes to simplify AJAX interaction
 
 ## FILES
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
  script has many formatting and operational options, most of which can be 
  specified within a variable file "_variables.php" each form.
 
+## To do
+
+These changes apply to my fork of the software. This file does not need to be merged into `foonster/postman`.
+
+- [x] Place variables used by Postman into an array, to prevent from filling the global namespace
+- [] Separate functionality of `Email.php` into individual classes
+- [] Send `Content-Type: application/json` with JSON responses; perhaps send proper HTTP status codes to simplify AJAX interaction
+
 ## FILES
 
 _postman.php - main processing file.

--- a/example.php
+++ b/example.php
@@ -146,7 +146,7 @@ if ( $_SERVER['REQUEST_METHOD'] == 'GET' || !empty( $_POST ) )
 		<label for="fupd_1">File:</label>
 		<input type="file" name="fupd_1" id="fupd_1"/><p />
 
-		<div class="g-recaptcha" data-sitekey="<?= $googleSiteKey ?>"></div>
+		<div class="g-recaptcha" data-sitekey="<?= $postman['google']['site_key'] ?>"></div>
 
 		<input type="submit" name="sbmtbtn" id="sbmtbtn" value="Send Form" class="btn">
 


### PR DESCRIPTION
This hotfix changes `$googleSiteKey` to `$postman['google']['site_key']` in `example.php` at Bryan's request. 
